### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ A 2d metaball loading
 
 ----------
 
-##ScreenShot
+## ScreenShot
 
 
 ![GIF example](metaball.gif)
 
-##Update
+## Update
 
-###1. 增加了调试模式，可以调整参数看看对图形的影响
+### 1. 增加了调试模式，可以调整参数看看对图形的影响
 
 ![GIF example](metaball2.gif)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
